### PR TITLE
feat(routes): add list page

### DIFF
--- a/lib/src/pages/routes_page.dart
+++ b/lib/src/pages/routes_page.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:train_simulator_client/train_simulator_client.dart' hide Key;
+import 'package:train_simulator_utilities/src/states/app_state.dart';
+import 'package:train_simulator_utilities/src/widgets/app_drawer.dart';
+
+class RoutesPage extends StatefulWidget {
+  const RoutesPage({
+    Key key,
+  }) : super(
+          key: key,
+        );
+
+  @override
+  _RoutesPageState createState() => _RoutesPageState();
+}
+
+class _RoutesPageState extends State<RoutesPage> {
+  Future<List<CRouteProperties>> _future;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Routes'),
+      ),
+      body: FutureBuilder<List<CRouteProperties>>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.done) {
+            return ListView.builder(
+              itemBuilder: (context, index) {
+                return ListTile(
+                  title: Text(
+                    snapshot.data[index].id1.cGuid.devString.toString(),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  subtitle: Text(
+                    snapshot.data[index].displayName
+                        .localisationCUserLocalisedString.english
+                        .toString(),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                );
+              },
+              itemCount: snapshot.data.length,
+            );
+          } else {
+            return Center(
+              child: CircularProgressIndicator(),
+            );
+          }
+        },
+      ),
+      drawer: AppDrawer(),
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _future = AppState.of(context).client.routes.get().toList();
+  }
+}

--- a/lib/src/router_delegates/app_router_delegate.dart
+++ b/lib/src/router_delegates/app_router_delegate.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:train_simulator_utilities/src/configurations/router_configuration.dart';
 import 'package:train_simulator_utilities/src/pages/home_page.dart';
+import 'package:train_simulator_utilities/src/pages/routes_page.dart';
 import 'package:train_simulator_utilities/src/pages/settings_page.dart';
 import 'package:train_simulator_utilities/src/route_paths/home_route_path.dart';
+import 'package:train_simulator_utilities/src/route_paths/routes_route_path.dart';
 import 'package:train_simulator_utilities/src/route_paths/settings_route_path.dart';
 import 'package:train_simulator_utilities/src/states/router_state.dart';
 
@@ -30,6 +32,11 @@ class AppRouterDelegate extends RouterDelegate<RouterConfiguration>
             child: const HomePage(),
             key: const Key('home_page'),
           ),
+          if (notifier.path is RoutesRoutePath)
+            const MaterialPage<void>(
+              child: const RoutesPage(),
+              key: const Key('routes_page'),
+            ),
           if (notifier.path is SettingsRoutePath)
             const MaterialPage<void>(
               child: const SettingsPage(),
@@ -41,7 +48,9 @@ class AppRouterDelegate extends RouterDelegate<RouterConfiguration>
           final success = route.didPop(result);
 
           if (success) {
-            if (path is SettingsRoutePath) {
+            if (path is RoutesRoutePath) {
+              notifier.path = const HomeRoutePath();
+            } else if (path is SettingsRoutePath) {
               notifier.path = const HomeRoutePath();
             }
           }

--- a/lib/src/widgets/app_drawer.dart
+++ b/lib/src/widgets/app_drawer.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:mdi/mdi.dart';
 import 'package:train_simulator_utilities/src/route_paths/home_route_path.dart';
+import 'package:train_simulator_utilities/src/route_paths/routes_route_path.dart';
 import 'package:train_simulator_utilities/src/route_paths/settings_route_path.dart';
+import 'package:train_simulator_utilities/src/states/app_state.dart';
 import 'package:train_simulator_utilities/src/states/router_state.dart';
 
 class AppDrawer extends StatelessWidget {
@@ -15,7 +17,7 @@ class AppDrawer extends StatelessWidget {
   Widget build(BuildContext context) {
     return Drawer(
       child: ListView(
-        children: [
+        children: <Widget>[
           DrawerHeader(
             decoration: BoxDecoration(
               color: Theme.of(context).colorScheme.primary,
@@ -28,6 +30,16 @@ class AppDrawer extends StatelessWidget {
             onTap: () {
               Navigator.of(context).pop();
               RouterState.of(context).path = const HomeRoutePath();
+            },
+          ),
+          const Divider(),
+          ListTile(
+            leading: Icon(Mdi.routes),
+            title: Text('Routes'),
+            enabled: AppState.of(context).client != null,
+            onTap: () {
+              Navigator.of(context).pop();
+              RouterState.of(context).path = const RoutesRoutePath();
             },
           ),
           const Divider(),


### PR DESCRIPTION
**Describe the change**
A routes page has been added which shows a list of routes.

**Current behavior**
It is currently not possible to view a list of routes.

**New behavior**
It is now possible to view a list of routes via the routes page.

**Additional context**
Only routes that are not in a `MainContent.ap` are currently shown.
