### PR TITLE
feat(routes): add search

### DIFF
--- a/lib/src/pages/routes_page.dart
+++ b/lib/src/pages/routes_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:mdi/mdi.dart';
 import 'package:train_simulator_client/train_simulator_client.dart' hide Key;
 import 'package:train_simulator_utilities/src/route_paths/route_route_path.dart';
+import 'package:train_simulator_utilities/src/search_delegates/route_search_delegate.dart';
 import 'package:train_simulator_utilities/src/states/app_state.dart';
 import 'package:train_simulator_utilities/src/states/router_state.dart';
 import 'package:train_simulator_utilities/src/widgets/app_drawer.dart';
@@ -24,6 +26,24 @@ class _RoutesPageState extends State<RoutesPage> {
     return Scaffold(
       appBar: AppBar(
         title: Text('Routes'),
+        actions: <Widget>[
+          IconButton(
+            icon: Icon(Mdi.magnify),
+            onPressed: () async {
+              final route = await showSearch(
+                context: context,
+                delegate: RouteSearchDelegate(),
+              );
+
+              if (route != null) {
+                RouterState.of(context).path = RouteRoutePath(
+                  id: route.id1.cGuid.devString.toString(),
+                );
+              }
+            },
+            tooltip: 'Search',
+          ),
+        ],
       ),
       body: FutureBuilder<List<CRouteProperties>>(
         future: _future,

--- a/lib/src/search_delegates/route_search_delegate.dart
+++ b/lib/src/search_delegates/route_search_delegate.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:mdi/mdi.dart';
+import 'package:train_simulator_client/train_simulator_client.dart';
+import 'package:train_simulator_utilities/src/states/app_state.dart';
+
+class RouteSearchDelegate extends SearchDelegate<CRouteProperties> {
+  @override
+  List<Widget> buildActions(BuildContext context) {
+    return <Widget>[
+      IconButton(
+        icon: const Icon(Mdi.close),
+        onPressed: () {
+          query = '';
+          showSuggestions(context);
+        },
+        tooltip: 'Clear',
+      ),
+    ];
+  }
+
+  @override
+  Widget buildLeading(BuildContext context) {
+    return IconButton(
+      icon: AnimatedIcon(
+        icon: AnimatedIcons.menu_arrow,
+        progress: transitionAnimation,
+      ),
+      onPressed: () {
+        close(context, null);
+      },
+      tooltip: 'Back',
+    );
+  }
+
+  @override
+  Widget buildResults(BuildContext context) {
+    return FutureBuilder<List<CRouteProperties>>(
+      future: AppState.of(context)
+          .client
+          .routes
+          .get()
+          .where((cRouteProperties) => cRouteProperties
+              .displayName.localisationCUserLocalisedString.english
+              .toString()
+              .toLowerCase()
+              .contains(query.toLowerCase()))
+          .toList(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.done) {
+          return ListView.builder(
+            itemBuilder: (context, index) {
+              return ListTile(
+                title: Text(
+                  snapshot.data[index].displayName
+                      .localisationCUserLocalisedString.english
+                      .toString(),
+                ),
+                onTap: () {
+                  close(context, snapshot.data[index]);
+                },
+              );
+            },
+            itemCount: snapshot.data.length,
+          );
+        } else {
+          return Center(
+            child: CircularProgressIndicator(),
+          );
+        }
+      },
+    );
+  }
+
+  @override
+  Widget buildSuggestions(BuildContext context) {
+    return ListView();
+  }
+}


### PR DESCRIPTION
**Describe the change**
A search delegate has been added which allows the user to search for a route.

**Current behavior**
It is currently not possible to search for a route.

**New behavior**
It is now possible to search for a route via the search delegate.

**Additional context**
It is only possible to search for a route by display name.
